### PR TITLE
fix(script): fix install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ echo "installing $package"
 temp=$(mktemp -d)
 
 plugin_dir="${HOME}/homebrew/plugins/${package}"
-mkdir -p $plugin_dir
+sudo mkdir -p $plugin_dir
 
 use_jq=false
 if [ -x "$(command -v jq)" ]; then


### PR DESCRIPTION
```bash
$ curl -L https://raw.githubusercontent.com/honjow/GPD-WinControl/main/install.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1324  100  1324    0     0   9101      0 --:--:-- --:--:-- --:--:--  9131
installing GPD-WinControl
mkdir: cannot create directory ‘/home/deck/homebrew/plugins/GPD-WinControl’: Permission denied
```

fix install script

Note, this bug is also in the PowerControl install script